### PR TITLE
Fixed app crashing when the stored MetadataPath is invalid on launch

### DIFF
--- a/Daf.Meta.Editor/ViewModels/MainViewModel.cs
+++ b/Daf.Meta.Editor/ViewModels/MainViewModel.cs
@@ -204,7 +204,16 @@ namespace Daf.Meta.Editor.ViewModels
 		private static void LoadMetadata()
 		{
 			if (MetadataPath != null)
-				Model.Deserialize(MetadataPath);
+			{
+				if (File.Exists(Path.Combine(MetadataPath, "Model.json")))
+					Model.Deserialize(MetadataPath);
+				else
+				{
+					MetadataPath = null;
+					MessageBox.Show("Stored Metadata path invalid. Initializing empty project instead.", "ERROR", MessageBoxButton.OK, MessageBoxImage.Error);
+					Model.Initialize(); // Create an empty Model.
+				}
+			}
 			else
 				Model.Initialize(); // Create an empty Model.
 		}

--- a/Daf.Meta.Editor/ViewModels/MainViewModel.cs
+++ b/Daf.Meta.Editor/ViewModels/MainViewModel.cs
@@ -210,7 +210,7 @@ namespace Daf.Meta.Editor.ViewModels
 				else
 				{
 					MetadataPath = null;
-					MessageBox.Show("Stored Metadata path invalid. Initializing empty project instead.", "ERROR", MessageBoxButton.OK, MessageBoxImage.Error);
+					MessageBox.Show("Stored Metadata path is invalid. Initializing an empty project instead.", "ERROR", MessageBoxButton.OK, MessageBoxImage.Error);
 					Model.Initialize(); // Create an empty Model.
 				}
 			}


### PR DESCRIPTION
App crashes when attempting to load metadata from a path that is invalid. For example, if the files are moved or deleted in-between sessions.

I've fixed this in the LoadMetadata method in MainViewModel but since we're doing the same check when opening new files and may want to do it elsewhere as well it might be an idea to implement a more thorough approach.

Another option would be to do this check in the getter for the MetadataPath-property in MainViewModel so the path gets validated any time it is accessed.

![image](https://user-images.githubusercontent.com/74718894/114171440-94479380-9934-11eb-8caa-739afa7285fc.png)
