### PR TITLE
Implemented exit click event from File menu for Datawarehouse, Connections, SourceSystems and Tenants Windows

### DIFF
--- a/Daf.Meta.Editor/Windows/ConnectionsWindow.xaml
+++ b/Daf.Meta.Editor/Windows/ConnectionsWindow.xaml
@@ -27,7 +27,7 @@
 		<DockPanel>
 			<Menu DockPanel.Dock="Top" Height="20" Background="Transparent" >
 				<MenuItem Header="_File">
-					<MenuItem Header="_Close" />
+					<MenuItem Header="_Close" Click="Exit_Click"/>
 				</MenuItem>
 			</Menu>
 			<ToolBarTray DockPanel.Dock="Top" IsLocked="True">

--- a/Daf.Meta.Editor/Windows/ConnectionsWindow.xaml.cs
+++ b/Daf.Meta.Editor/Windows/ConnectionsWindow.xaml.cs
@@ -11,5 +11,10 @@ namespace Daf.Meta.Editor.Windows
 		{
 			InitializeComponent();
 		}
+
+		private void Exit_Click(object sender, RoutedEventArgs e)
+		{
+			Close();
+		}
 	}
 }

--- a/Daf.Meta.Editor/Windows/DataWarehouseWindow.xaml
+++ b/Daf.Meta.Editor/Windows/DataWarehouseWindow.xaml
@@ -30,7 +30,7 @@
 		<DockPanel>
 			<Menu DockPanel.Dock="Top" Height="20" Background="Transparent" >
 				<MenuItem Header="_File">
-					<MenuItem Header="_Close" />
+					<MenuItem Header="_Close" Click="Exit_Click"/>
 				</MenuItem>
 			</Menu>
 			<pt:PropertyGrid SelectedObject="{Binding}" TabVisibility="Collapsed" ControlFactory="{StaticResource CustomControlFactory}" />

--- a/Daf.Meta.Editor/Windows/DataWarehouseWindow.xaml.cs
+++ b/Daf.Meta.Editor/Windows/DataWarehouseWindow.xaml.cs
@@ -15,6 +15,11 @@ namespace Daf.Meta.Editor.Windows
 		{
 			InitializeComponent();
 		}
+
+		private void Exit_Click(object sender, RoutedEventArgs e)
+		{
+			Close();
+		}
 	}
 
 	public class DictionaryValueConverter : IValueConverter

--- a/Daf.Meta.Editor/Windows/SourceSystemsWindow.xaml
+++ b/Daf.Meta.Editor/Windows/SourceSystemsWindow.xaml
@@ -19,7 +19,7 @@
 		<DockPanel>
 			<Menu DockPanel.Dock="Top" Height="20" Background="Transparent" >
 				<MenuItem Header="_File">
-					<MenuItem Header="_Close" />
+					<MenuItem Header="_Close" Click="Exit_Click"/>
 				</MenuItem>
 			</Menu>
 			<ToolBarTray DockPanel.Dock="Top" IsLocked="True">

--- a/Daf.Meta.Editor/Windows/SourceSystemsWindow.xaml.cs
+++ b/Daf.Meta.Editor/Windows/SourceSystemsWindow.xaml.cs
@@ -11,5 +11,10 @@ namespace Daf.Meta.Editor.Windows
 		{
 			InitializeComponent();
 		}
+
+		private void Exit_Click(object sender, RoutedEventArgs e)
+		{
+			Close();
+		}
 	}
 }

--- a/Daf.Meta.Editor/Windows/TenantsWindow.xaml
+++ b/Daf.Meta.Editor/Windows/TenantsWindow.xaml
@@ -19,7 +19,7 @@
 		<DockPanel>
 			<Menu DockPanel.Dock="Top" Height="20" Background="Transparent" >
 				<MenuItem Header="_File">
-					<MenuItem Header="_Close" />
+					<MenuItem Header="_Close" Click="Exit_Click"/>
 				</MenuItem>
 			</Menu>
 			<ToolBarTray DockPanel.Dock="Top" IsLocked="True">

--- a/Daf.Meta.Editor/Windows/TenantsWindow.xaml.cs
+++ b/Daf.Meta.Editor/Windows/TenantsWindow.xaml.cs
@@ -11,5 +11,10 @@ namespace Daf.Meta.Editor.Windows
 		{
 			InitializeComponent();
 		}
+
+		private void Exit_Click(object sender, RoutedEventArgs e)
+		{
+			Close();
+		}
 	}
 }


### PR DESCRIPTION
These were already implemented in the GUI but had not yet had click events implemented for them. Can merge if there are no errors found after review.