### PR TITLE
Added property for target platform assembly version

### DIFF
--- a/Daf.Meta/DataWarehouse.cs
+++ b/Daf.Meta/DataWarehouse.cs
@@ -1,6 +1,8 @@
 ﻿// SPDX-License-Identifier: MIT
 // Copyright © 2021 Oscar Björhn, Petter Löfgren and contributors
 
+using System;
+using System.Globalization;
 using Daf.Meta.Layers.Connections;
 
 namespace Daf.Meta
@@ -48,6 +50,21 @@ namespace Daf.Meta
 
 					NotifyPropertyChanged("TargetPlatformVersion");
 				}
+			}
+		}
+
+		public string? TargetPlatformAssemblyVersion
+		{
+			get
+			{
+				int assemblyVersion = (int)Enum.Parse(typeof(SqlServerVersion), TargetPlatform + TargetPlatformVersion);
+
+				if (TargetPlatform == "SqlServer")
+				{
+					return assemblyVersion.ToString(CultureInfo.InvariantCulture);
+				}
+
+				return "";
 			}
 		}
 

--- a/Daf.Meta/DataWarehouse.cs
+++ b/Daf.Meta/DataWarehouse.cs
@@ -53,14 +53,14 @@ namespace Daf.Meta
 			}
 		}
 
-		public string? TargetPlatformAssemblyVersion
+		public string TargetPlatformAssemblyVersion
 		{
 			get
 			{
-				int assemblyVersion = (int)Enum.Parse(typeof(SqlServerVersion), TargetPlatform + TargetPlatformVersion);
-
 				if (TargetPlatform == "SqlServer")
 				{
+					int assemblyVersion = (int)Enum.Parse(typeof(SqlServerVersion), TargetPlatform + TargetPlatformVersion);
+
 					return assemblyVersion.ToString(CultureInfo.InvariantCulture);
 				}
 

--- a/Daf.Meta/Enums.cs
+++ b/Daf.Meta/Enums.cs
@@ -52,4 +52,12 @@ namespace Daf.Meta
 	{
 		Password
 	}
+
+	[System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "CA1008:Enums should have zero value", Justification = "Doesn't apply here.")]
+	public enum SqlServerVersion
+	{
+		SqlServer2016 = 13,
+		SqlServer2017 = 14,
+		SqlServer2019 = 15
+	}
 }


### PR DESCRIPTION
Matching e.g. TargetPlatform + TargetPlatformVersion which could be for instance SqlServer2016 against e.g. assembly major version 13 and so on.